### PR TITLE
Adicionado modificações para o uso de multithread na classe ConfiguracaoServico

### DIFF
--- a/NFE.Testes/NFeTestes.cs
+++ b/NFE.Testes/NFeTestes.cs
@@ -1,0 +1,79 @@
+﻿using DFe.Classes.Entidades;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NFe.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NFE.Testes
+{
+    [TestClass]
+    public class NFeTestes
+    {
+        public class ConfigurationTests
+        {
+            public Estado State { get; set; }
+            public TimeSpan SleepTime { get; set; }
+        }
+
+        [TestMethod]
+        public void NFeConfiguracaoService_WhenTryCallAsynchronously_ReturnsTheSameInstance()
+        {
+            var configuration1 = new ConfigurationTests { State = Estado.AC, SleepTime = TimeSpan.FromSeconds(10) };
+            var configuration2 = new ConfigurationTests { State = Estado.AM, SleepTime = TimeSpan.FromSeconds(2) };
+            var configuration3 = new ConfigurationTests { State = Estado.AP, SleepTime = TimeSpan.FromSeconds(0) };
+            var configuration4 = new ConfigurationTests { State = Estado.SP, SleepTime = TimeSpan.FromSeconds(3) };
+
+            ConfigurationTests[] configurations = { configuration1, configuration2, configuration3, configuration4 };
+
+            foreach (var configuration in configurations)
+            {
+                Task.Run(() =>
+                {
+                    var service = new ConfiguracaoServico();
+                    service.cUF = configuration.State;
+
+                    Thread.Sleep(configuration.SleepTime);
+
+                    // Arrange
+                    Assert.IsNotNull(service.cUF);
+                    Assert.AreEqual(service.cUF, configuration.State);
+                }
+                );
+            }
+
+            Thread.Sleep(TimeSpan.FromSeconds(12));
+        }
+
+        [TestMethod]
+        public void NFeConfiguracaoService_WhenTryCallAsynchronously_ReturnsWrongInstance()
+        {
+            var configuration1 = new ConfigurationTests { State = Estado.AC, SleepTime = TimeSpan.FromSeconds(10) };
+            var configuration2 = new ConfigurationTests { State = Estado.AM, SleepTime = TimeSpan.FromSeconds(2) };
+            var configuration3 = new ConfigurationTests { State = Estado.AP, SleepTime = TimeSpan.FromSeconds(0) };
+            var configuration4 = new ConfigurationTests { State = Estado.SP, SleepTime = TimeSpan.FromSeconds(3) };
+
+            ConfigurationTests[] configurations = { configuration1, configuration2, configuration3, configuration4 };
+
+            foreach (var configuration in configurations)
+            {
+                Task.Run(() =>
+                {
+                    ConfiguracaoServico.Instancia.cUF = configuration.State;
+
+                    Thread.Sleep(configuration.SleepTime);
+
+                    // Arrange
+                    Assert.IsNotNull(ConfiguracaoServico.Instancia.cUF);
+                    Assert.AreEqual(ConfiguracaoServico.Instancia.cUF, configuration.State);
+                }
+                );
+            }
+
+            Thread.Sleep(TimeSpan.FromSeconds(12));
+        }
+    }
+}

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -247,7 +247,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlStatus = pedStatus.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeStatusServico, _cFgServico.VersaoNfeStatusServico, xmlStatus);
+            Validador.Valida(ServicoNFe.NfeStatusServico, _cFgServico.VersaoNfeStatusServico, xmlStatus, cfgServico: _cFgServico);
             var dadosStatus = new XmlDocument();
             dadosStatus.LoadXml(xmlStatus);
 
@@ -309,7 +309,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlConsulta = pedConsulta.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeConsultaProtocolo, _cFgServico.VersaoNfeConsultaProtocolo, xmlConsulta);
+            Validador.Valida(ServicoNFe.NfeConsultaProtocolo, _cFgServico.VersaoNfeConsultaProtocolo, xmlConsulta, cfgServico: _cFgServico);
             var dadosConsulta = new XmlDocument();
             dadosConsulta.LoadXml(xmlConsulta);
 
@@ -397,7 +397,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlInutilizacao = pedInutilizacao.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeInutilizacao, _cFgServico.VersaoNfeInutilizacao, xmlInutilizacao);
+            Validador.Valida(ServicoNFe.NfeInutilizacao, _cFgServico.VersaoNfeInutilizacao, xmlInutilizacao, cfgServico: _cFgServico);
             var dadosInutilizacao = new XmlDocument();
             dadosInutilizacao.LoadXml(xmlInutilizacao);
 
@@ -481,7 +481,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlEvento = pedEvento.ObterXmlString();
-            Validador.Valida(servicoEvento, _cFgServico.VersaoRecepcaoEventoCceCancelamento, xmlEvento);
+            Validador.Valida(servicoEvento, _cFgServico.VersaoRecepcaoEventoCceCancelamento, xmlEvento, cfgServico: _cFgServico);
             var dadosEvento = new XmlDocument();
             dadosEvento.LoadXml(xmlEvento);
 
@@ -770,7 +770,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlConsulta = pedConsulta.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeConsultaCadastro, _cFgServico.VersaoNfeConsultaCadastro, xmlConsulta);
+            Validador.Valida(ServicoNFe.NfeConsultaCadastro, _cFgServico.VersaoNfeConsultaCadastro, xmlConsulta, cfgServico: _cFgServico);
             var dadosConsulta = new XmlDocument();
             dadosConsulta.LoadXml(xmlConsulta);
 
@@ -857,7 +857,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlConsulta = pedDistDFeInt.ObterXmlString();
-            Validador.Valida(ServicoNFe.NFeDistribuicaoDFe, _cFgServico.VersaoNFeDistribuicaoDFe, xmlConsulta);
+            Validador.Valida(ServicoNFe.NFeDistribuicaoDFe, _cFgServico.VersaoNFeDistribuicaoDFe, xmlConsulta, cfgServico: _cFgServico);
             var dadosConsulta = new XmlDocument();
             dadosConsulta.LoadXml(xmlConsulta);
 
@@ -959,7 +959,7 @@ namespace NFe.Servicos
                 //Caso o lote seja enviado para o PR, colocar o namespace nos elementos <NFe> do lote, pois o serviço do PR o exige, conforme https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/33
                 xmlEnvio = xmlEnvio.Replace("<NFe>", "<NFe xmlns=\"http://www.portalfiscal.inf.br/nfe\">");
 
-            Validador.Valida(ServicoNFe.NfeRecepcao, _cFgServico.VersaoNfeRecepcao, xmlEnvio);
+            Validador.Valida(ServicoNFe.NfeRecepcao, _cFgServico.VersaoNfeRecepcao, xmlEnvio, cfgServico: _cFgServico);
             var dadosEnvio = new XmlDocument();
             dadosEnvio.LoadXml(xmlEnvio);
 
@@ -1089,7 +1089,7 @@ namespace NFe.Servicos
                 //Caso o lote seja enviado para o PR, colocar o namespace nos elementos <NFe> do lote, pois o serviço do PR o exige, conforme https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/33
                 xmlEnvio = xmlEnvio.Replace("<NFe>", "<NFe xmlns=\"http://www.portalfiscal.inf.br/nfe\">");
 
-            Validador.Valida(ServicoNFe.NFeAutorizacao, _cFgServico.VersaoNFeAutorizacao, xmlEnvio);
+            Validador.Valida(ServicoNFe.NFeAutorizacao, _cFgServico.VersaoNFeAutorizacao, xmlEnvio, cfgServico: _cFgServico);
             var dadosEnvio = new XmlDocument();
             dadosEnvio.LoadXml(xmlEnvio);
 
@@ -1222,7 +1222,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlDownload = pedDownload.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeDownloadNF, _cFgServico.VersaoNfeDownloadNF, xmlDownload);
+            Validador.Valida(ServicoNFe.NfeDownloadNF, _cFgServico.VersaoNfeDownloadNF, xmlDownload, cfgServico: _cFgServico);
             var dadosDownload = new XmlDocument();
             dadosDownload.LoadXml(xmlDownload);
 

--- a/NFe.Utils/Assinatura/Assinador.cs
+++ b/NFe.Utils/Assinatura/Assinador.cs
@@ -42,6 +42,14 @@ namespace NFe.Utils.Assinatura
 {
     public static class Assinador
     {
+        public static Signature ObterAssinatura<T>(T objeto, string id, ConfiguracaoServico cfgServico = null) where T : class
+        {
+            if (cfgServico == null)
+                cfgServico = ConfiguracaoServico.Instancia;
+
+            return ObterAssinatura<T>(objeto, id, CertificadoDigital.ObterCertificado(cfgServico.Certificado), cfgServico.Certificado.ManterDadosEmCache);
+        }
+
         /// <summary>
         ///     Obtém a assinatura de um objeto serializável
         /// </summary>
@@ -50,18 +58,17 @@ namespace NFe.Utils.Assinatura
         /// <param name="id"></param>
         /// <param name="certificadoDigital">Informe o certificado digital, se já possuir esse em cache, evitando novo acesso ao certificado</param>
         /// <returns>Retorna um objeto do tipo Classes.Assinatura.Signature, contendo a assinatura do objeto passado como parâmetro</returns>
-        public static Signature ObterAssinatura<T>(T objeto, string id, X509Certificate2 certificadoDigital = null) where T : class
+        public static Signature ObterAssinatura<T>(T objeto, string id, X509Certificate2 certificadoDigital, bool manterDadosEmCache = true) where T : class
         {
             var objetoLocal = objeto;
             if (id == null)
                 throw new Exception("Não é possível assinar um objeto evento sem sua respectiva Id!");
 
-            var certificado = certificadoDigital ?? CertificadoDigital.ObterCertificado(ConfiguracaoServico.Instancia.Certificado);
             try
             {
                 var documento = new XmlDocument { PreserveWhitespace = true };
                 documento.LoadXml(FuncoesXml.ClasseParaXmlString(objetoLocal));
-                var docXml = new SignedXml(documento) { SigningKey = certificado.PrivateKey };
+                var docXml = new SignedXml(documento) { SigningKey = certificadoDigital.PrivateKey };
                 var reference = new Reference { Uri = "#" + id };
 
                 // adicionando EnvelopedSignatureTransform a referencia
@@ -75,7 +82,7 @@ namespace NFe.Utils.Assinatura
 
                 // carrega o certificado em KeyInfoX509Data para adicionar a KeyInfo
                 var keyInfo = new KeyInfo();
-                keyInfo.AddClause(new KeyInfoX509Data(certificado));
+                keyInfo.AddClause(new KeyInfoX509Data(certificadoDigital));
 
                 docXml.KeyInfo = keyInfo;
                 docXml.ComputeSignature();
@@ -89,8 +96,8 @@ namespace NFe.Utils.Assinatura
             {
                 //Se não mantém os dados do certificado em cache e o certificado não foi passado por parâmetro(isto é, ele foi criado dentro deste método), 
                 //então libera o certificado, chamando o método reset.
-                if (!ConfiguracaoServico.Instancia.Certificado.ManterDadosEmCache & certificadoDigital == null)
-                    certificado.Reset();
+                if (!manterDadosEmCache & certificadoDigital == null)
+                    certificadoDigital.Reset();
             }
            
         }

--- a/NFe.Utils/ConfiguracaoServico.cs
+++ b/NFe.Utils/ConfiguracaoServico.cs
@@ -49,9 +49,13 @@ namespace NFe.Utils
         private string _diretorioSchemas;
         private bool _salvarXmlServicos;
 
-        private ConfiguracaoServico()
+        public ConfiguracaoServico()
         {
             Certificado = new ConfiguracaoCertificado();
+        }
+
+        static ConfiguracaoServico()
+        {
         }
 
         /// <summary>

--- a/NFe.Utils/NFe/ExtNFe.cs
+++ b/NFe.Utils/NFe/ExtNFe.cs
@@ -99,9 +99,9 @@ namespace NFe.Utils.NFe
             var xmlNfe = nfe.ObterXmlString();
             var cfgServico = ConfiguracaoServico.Instancia;
             if (versao < 3)
-                Validador.Valida(ServicoNFe.NfeRecepcao, cfgServico.VersaoNfeRecepcao, xmlNfe, false);
+                Validador.Valida(ServicoNFe.NfeRecepcao, cfgServico.VersaoNfeRecepcao, xmlNfe, false, cfgServico);
             if (versao >= 3)
-                Validador.Valida(ServicoNFe.NFeAutorizacao, cfgServico.VersaoNFeAutorizacao, xmlNfe, false);
+                Validador.Valida(ServicoNFe.NFeAutorizacao, cfgServico.VersaoNFeAutorizacao, xmlNfe, false, cfgServico);
 
             return nfe; //Para uso no formato fluent
         }
@@ -111,7 +111,7 @@ namespace NFe.Utils.NFe
         /// </summary>
         /// <param name="nfe"></param>
         /// <returns>Retorna um objeto do tipo NFe assinado</returns>
-        public static Classes.NFe Assina(this Classes.NFe nfe)
+        public static Classes.NFe Assina(this Classes.NFe nfe, ConfiguracaoServico cfgServico = null)
         {
             var nfeLocal = nfe;
             if (nfeLocal == null) throw new ArgumentNullException("nfe");
@@ -139,7 +139,7 @@ namespace NFe.Utils.NFe
             nfeLocal.infNFe.Id = "NFe" + dadosChave.Chave;
             nfeLocal.infNFe.ide.cDV = Convert.ToInt16(dadosChave.DigitoVerificador);
 
-            var assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id);
+            var assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, cfgServico);
             nfeLocal.Signature = assinatura;
             return nfeLocal;
         }

--- a/NFe.Utils/Validacao/Validador.cs
+++ b/NFe.Utils/Validacao/Validador.cs
@@ -94,10 +94,20 @@ namespace NFe.Utils.Validacao
             return null;
         }
 
-        public static void Valida(ServicoNFe servicoNFe, VersaoServico versaoServico, string stringXml, bool loteNfe = true)
+        public static void Valida(ServicoNFe servicoNFe, VersaoServico versaoServico, string stringXml, bool loteNfe = true, ConfiguracaoServico cfgServico = null)
         {
-            var pathSchema = ConfiguracaoServico.Instancia.DiretorioSchemas;
+            var pathSchema = String.Empty;
 
+            if (cfgServico == null || (cfgServico != null && string.IsNullOrWhiteSpace(cfgServico.DiretorioSchemas)))
+                pathSchema = ConfiguracaoServico.Instancia.DiretorioSchemas;
+            else
+                pathSchema = cfgServico.DiretorioSchemas;
+
+            Valida(servicoNFe, versaoServico, stringXml, loteNfe, pathSchema);
+        }
+
+        public static void Valida(ServicoNFe servicoNFe, VersaoServico versaoServico, string stringXml, bool loteNfe = true, string pathSchema = null)
+        {
             if (!Directory.Exists(pathSchema))
                 throw new Exception("Diretório de Schemas não encontrado: \n" + pathSchema);
 


### PR DESCRIPTION
Adicionado a possibilidade de criação de mais de um objeto ConfiguracaoServico, possibilitando o uso de multithreads e multiempresas. Desta forma, também será mantido o uso de modo estático.